### PR TITLE
feat: Adding index to relevance_table on user_id column

### DIFF
--- a/database/migrations/create_relevance_table.php
+++ b/database/migrations/create_relevance_table.php
@@ -14,6 +14,8 @@ return new class () extends Migration {
             $table->string(config('relevance.database.relevance_relation_column_name', 'relation_name'));
             $table->timestamps();
             $table->softDeletes();
+
+            $table->index(config('relevance.database.relevance_user_foreign_key_column_name', 'user_id'));
         });
     }
 };


### PR DESCRIPTION
Base the fact that relevance table will be a huge after a while, I've added an index for user_id column so looking for user relevances will be faster in the future. Adding an index to relation_name column might be another option.